### PR TITLE
Add OpenAI prompt support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ttkbootstrap
 pyserial
+openai


### PR DESCRIPTION
## Summary
- integrate OpenAI client into DevCenter
- expose a chat prompt entry in the IA panel
- save history and display answer in logs
- add OpenAI requirement

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile main_gui.py hardware.py`


------
https://chatgpt.com/codex/tasks/task_e_6859506e947483239262c2fe4c5f3be5