### PR TITLE
Use repo URL from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Développé par **NovaDevSysthem** avec l’assistance d’agents IA sur-mesure.
 - **Branding** :  
     - Change la bannière de l’UI dans `main_gui.py`  
     - Ajoute ton nom dans le footer, et dans ce README  
-    - Modifie l’URL du dépôt si besoin
+    - Personnalise l’URL du dépôt via `github_repo_url` dans `config.json` pour le bouton "Ouvrir Page GitHub"
 
 ---
 
@@ -59,6 +59,15 @@ Renseigne la clé dans `config.json` :
 ```json
 {
   "openai_api_key": "sk-..."
+}
+```
+
+Pour personnaliser le bouton "Ouvrir Page GitHub", ajoute la clé `github_repo_url` :
+
+```json
+{
+  "openai_api_key": "sk-...",
+  "github_repo_url": "https://github.com/moncompte/mondepot"
 }
 ```
 

--- a/config.json
+++ b/config.json
@@ -1,3 +1,4 @@
 {
-  "openai_api_key": ""
+  "openai_api_key": "",
+  "github_repo_url": "https://github.com/TON-UTILISATEUR/TON-DEPOT"
 }

--- a/main_gui.py
+++ b/main_gui.py
@@ -245,8 +245,16 @@ def reset_git():
 def push_github():
     return "[GIT] Simu push (à brancher sur Git réel)"
 
-def open_github_repo():
-    url = "https://github.com/TON-UTILISATEUR/TON-DEPOT"
+def open_github_repo(url=None):
+    """Ouvre le dépôt GitHub défini dans config.json ou celui passé en param."""
+    if url is None:
+        try:
+            with open("config.json", "r", encoding="utf-8") as f:
+                url = json.load(f).get("github_repo_url")
+        except Exception:
+            url = None
+    if not url:
+        url = "https://github.com/TON-UTILISATEUR/TON-DEPOT"
     import webbrowser
     webbrowser.open(url)
     return "[GIT] Ouverture page GitHub."


### PR DESCRIPTION
## Summary
- configure repo URL with `github_repo_url` in `config.json`
- open GitHub repo using the configured link
- document how to customize the GitHub link

## Testing
- `python -m py_compile main_gui.py hardware.py`
- `flake8 main_gui.py hardware.py`

------
https://chatgpt.com/codex/tasks/task_e_685955bee1f08323b822b451848e7531