### PR TITLE
Add env var fallback for OpenAI key

### DIFF
--- a/project_utils.py
+++ b/project_utils.py
@@ -133,7 +133,7 @@ def ask_openai(prompt):
     try:
         with open("config.json", "r", encoding="utf-8") as f:
             config = json.load(f)
-        api_key = config.get("openai_api_key")
+        api_key = config.get("openai_api_key") or os.getenv("OPENAI_API_KEY")
         if not api_key:
             raise RuntimeError("Clé API OpenAI manquante")
         openai.api_key = api_key


### PR DESCRIPTION
## Summary
- support OPENAI_API_KEY env var in `ask_openai`
- test OpenAI key fallback to env var

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a86d868848323a086bb5a16aeaa66