### PR TITLE
Show font image in UI

### DIFF
--- a/DevCenter.spec
+++ b/DevCenter.spec
@@ -5,7 +5,7 @@ a = Analysis(
     ['main_gui.py'],
     pathex=[],
     binaries=[],
-    datas=[('dist/agents.json', 'dist')],
+    datas=[('dist/agents.json', 'dist'), ('img-font.png', '.')],
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},

--- a/README.md
+++ b/README.md
@@ -25,13 +25,16 @@ Développé par **NovaDevSysthem** avec l’assistance d’agents IA sur-mesure.
 
 ## 🏷️ Personnalisation
 
-- **Logo personnalisable** :  
+- **Logo personnalisable** :
     - Remplace `logo.ico` par ton icône, ou modifie la ligne dans `main_gui.py` :  
       ```python
       app.iconbitmap('logo.ico')  # Change le nom ici si besoin
       ```
     - Ajoute un logo dans le README via `![Logo](tonlogo.png)` si tu préfères un PNG (et update le chemin)
-- **Branding** :  
+- **Image de démo des polices** :
+    - `img-font.png` est affiché dans l'application (accueil & barre latérale).
+      Remplace-le par ton propre fichier si tu souhaites personnaliser l'image.
+- **Branding** :
     - Change la bannière de l’UI dans `main_gui.py`  
     - Ajoute ton nom dans le footer, et dans ce README  
     - Personnalise l’URL du dépôt via `github_repo_url` dans `config.json` pour le bouton "Ouvrir Page GitHub"

--- a/main_gui.py
+++ b/main_gui.py
@@ -1,6 +1,6 @@
 import ttkbootstrap as tb
 from ttkbootstrap.constants import *
-from tkinter import messagebox, scrolledtext
+from tkinter import messagebox, scrolledtext, PhotoImage
 import datetime
 import json
 import os
@@ -476,6 +476,13 @@ def run_app():
         font=("Segoe UI", 10),
         bootstyle="inverse-secondary",
     ).pack(pady=(0, 18))
+
+    # Image demo des polices
+    img_path = os.path.join(BASE_DIR, "img-font.png")
+    if os.path.exists(img_path):
+        img_font = PhotoImage(file=img_path)
+        tb.Label(sidebar, image=img_font).pack(pady=(0, 15))
+        sidebar.img_font = img_font  # reference
     # Sélecteur de thème
     tb.Label(
         sidebar,
@@ -568,6 +575,10 @@ def run_app():
     tb.Label(
         accueil_panel, text="Choisissez une section à gauche.", font=("Segoe UI", 13)
     ).pack()
+    if os.path.exists(img_path):
+        img_font_accueil = PhotoImage(file=img_path)
+        tb.Label(accueil_panel, image=img_font_accueil).pack(pady=10)
+        accueil_panel.img_font = img_font_accueil
     nav["accueil"] = accueil_panel
 
     projet_panel = tb.Frame(content)

--- a/main_gui.spec
+++ b/main_gui.spec
@@ -5,7 +5,7 @@ a = Analysis(
     ['main_gui.py'],
     pathex=[],
     binaries=[],
-    datas=[('dist/agents.json', 'dist')],
+    datas=[('dist/agents.json', 'dist'), ('img-font.png', '.')],
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},


### PR DESCRIPTION
## Summary
- load `img-font.png` and display it in the sidebar and welcome page
- document the new image usage in README
- include the image in PyInstaller specs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a900fef0883238787f89d9bd0b300