### PR TITLE
Add quick prompt on home

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ vers sa documentation officielle. Pour les variantes ESP32, utilisez l'option
 ## 🌟 UI & Navigation
 
 - **Barre latérale :** Accueil, Projet, IA, GitHub, Outils
-- **IA** :  
+- **Accueil** : prompt IA rapide
+- **IA** :
     - Liste des agents IA  
     - Créer un agent IA  
     - Paramètres IA globaux (clé API, source, etc.)


### PR DESCRIPTION
## Summary
- enable quick OpenAI prompts directly on the home panel
- share prompt-sending logic across panels
- show home prompt widgets disabled when OpenAI isn't configured
- document the new home capability

## Testing
- `pre-commit run --files main_gui.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a9c20be80832398cf4141d28c4bb8